### PR TITLE
Add dependent resource and disable ssa in MockOperatorTest.

### DIFF
--- a/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/ConfigMapDpendentResource.java
+++ b/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/ConfigMapDpendentResource.java
@@ -1,0 +1,29 @@
+package io.javaoperatorsdk.operator.springboot.starter.sample;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+
+@KubernetesDependent(labelSelector = "app.kubernetes.io/managed-by=custom-service-operator")
+public class ConfigMapDpendentResource
+    extends CRUDKubernetesDependentResource<ConfigMap, CustomService> {
+  public ConfigMapDpendentResource() {
+    super(ConfigMap.class);
+  }
+
+  @Override
+  protected ConfigMap desired(CustomService primary, Context<CustomService> context) {
+    return new ConfigMapBuilder()
+        .withMetadata(new ObjectMetaBuilder()
+            .withName(primary.getMetadata().getName() + "-config")
+            .withNamespace(primary.getMetadata().getNamespace())
+            .build())
+        .withData(Map.of("foo", "bar"))
+        .build();
+  }
+}

--- a/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/CustomServiceReconciler.java
+++ b/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/CustomServiceReconciler.java
@@ -12,9 +12,12 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.*;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 
 /** A very simple sample controller that creates a service with a label. */
-@ControllerConfiguration
+@ControllerConfiguration(dependents = {
+    @Dependent(name = "config", type = ConfigMapDpendentResource.class)
+})
 public class CustomServiceReconciler implements Reconciler<CustomService> {
 
   private static final Logger log = LoggerFactory.getLogger(CustomServiceReconciler.class);


### PR DESCRIPTION
Since operator-sdk 4.4 the default for ssa (Server-Side-Apply) switched to true (see https://github.com/operator-framework/java-operator-sdk/blob/08f8d854483e28f8147568aa09d585dca6b91810/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java#L332-L346C1)

This causes an exception when working with @Dependent resources and the MockOperator similar to the following:

```
2023-09-06T16:25:37.553+02:00 ERROR 90019 --- [cereconciler-42] i.j.o.p.event.ReconciliationDispatcher   : Error during event processing ExecutionScope{ resource id: ResourceID{name='test-name', namespace='test-ns'}, version: 4} failed.

io.javaoperatorsdk.operator.AggregatedOperatorException: Exception(s) during workflow execution. Details:
 - io.javaoperatorsdk.operator.springboot.starter.sample.ConfigMapDpendentResource -> io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://localhost:54195/api/v1/namespaces/test-ns/configmaps/test-name-config?fieldManager=customservicereconciler&force=true. Message: Not Found.
	at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:238)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:518)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:535)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handlePatch(OperationSupport.java:430)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handlePatch(OperationSupport.java:408)
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handlePatch(BaseOperation.java:713)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.lambda$patch$2(HasMetadataOperation.java:232)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.patch(HasMetadataOperation.java:237)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.patch(HasMetadataOperation.java:252)
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.serverSideApply(BaseOperation.java:1132)
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.serverSideApply(BaseOperation.java:92)
	at io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource.create(KubernetesDependentResource.java:140)
	at io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource.create(CRUDKubernetesDependentResource.java:16)
	at io.javaoperatorsdk.operator.processing.dependent.AbstractDependentResource.handleCreate(AbstractDependentResource.java:114)
	at io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource.handleCreate(KubernetesDependentResource.java:111)
	at io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource.handleCreate(KubernetesDependentResource.java:32)
	at io.javaoperatorsdk.operator.processing.dependent.AbstractDependentResource.reconcile(AbstractDependentResource.java:62)
	at io.javaoperatorsdk.operator.processing.dependent.SingleDependentResourceReconciler.reconcile(SingleDependentResourceReconciler.java:19)
	at io.javaoperatorsdk.operator.processing.dependent.AbstractDependentResource.reconcile(AbstractDependentResource.java:52)
	at io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowReconcileExecutor$NodeReconcileExecutor.doRun(WorkflowReconcileExecutor.java:115)
	at io.javaoperatorsdk.operator.processing.dependent.workflow.NodeExecutor.run(NodeExecutor.java:22)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://localhost:54195/api/v1/namespaces/test-ns/configmaps/test-name-config?fieldManager=customservicereconciler&force=true. Message: Not Found.
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:671)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:651)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.assertResponseCode(OperationSupport.java:600)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.lambda$handleResponse$0(OperationSupport.java:560)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
	at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$10(StandardHttpClient.java:140)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
	at io.fabric8.kubernetes.client.http.ByteArrayBodyHandler.onBodyDone(ByteArrayBodyHandler.java:52)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
	at io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl$OkHttpAsyncBody.doConsume(OkHttpClientImpl.java:137)
	... 3 more
```

To configure SSA we have to provide a Bean of type Consumer<ConfigurationServiceOverrider> and set `withSSABasedCreateUpdateMatchForDependentResources` to false.

I've added a sample dependent Resource and modified the test case accordingly.

* ConfigMapDependentResource: simple dependent configmap with dummy values
* CustomServiceReconciler: depend on ConfigMapDependentResource
* EnableMockOperatorTests: Add ConfigurationServiceOverride Bean to configure ssa, update test case