### PR TITLE
feat(actuator): adding operator health indicator

### DIFF
--- a/starter-test/pom.xml
+++ b/starter-test/pom.xml
@@ -42,6 +42,16 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.javaoperatorsdk</groupId>
       <artifactId>operator-framework</artifactId>
     </dependency>

--- a/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/HealthIndicatorTest.java
+++ b/starter-test/src/test/java/io/javaoperatorsdk/operator/springboot/starter/test/HealthIndicatorTest.java
@@ -1,0 +1,31 @@
+package io.javaoperatorsdk.operator.springboot.starter.test;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+    "management.endpoint.health.enabled=true", "management.endpoint.health.show-details=always"})
+@EnableMockOperator(crdPaths = "classpath:crd.yml")
+class HealthIndicatorTest {
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Test
+  void testOperatorHealthIndicator() {
+    ResponseEntity<String> entity =
+        this.restTemplate.getForEntity("/actuator/health", String.class);
+    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(entity.getBody()).contains("\"status\":\"UP\"");
+    assertThat(entity.getBody())
+        .contains(
+            "\"operator\":{\"status\":\"UP\",\"details\":{\"customservicereconciler\":\"OK\"}}");
+  }
+
+}

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -53,7 +53,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicator.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicator.java
@@ -1,0 +1,45 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import io.javaoperatorsdk.operator.Operator;
+
+@Component
+public class OperatorHealthIndicator extends AbstractHealthIndicator {
+
+  private final Operator operator;
+
+  public OperatorHealthIndicator(final Operator operator) {
+    super("OperatorSDK health check failed");
+    Assert.notNull(operator, "OperatorSDK Operator not initialized");
+    this.operator = operator;
+  }
+
+  @Override
+  protected void doHealthCheck(Health.Builder builder) {
+    final var runtimeInfo = operator.getRuntimeInfo();
+    if (runtimeInfo.isStarted()) {
+      final boolean[] healthy = {true};
+      runtimeInfo.getRegisteredControllers().forEach(rc -> {
+        final var name = rc.getConfiguration().getName();
+        final var unhealthy = rc.getControllerHealthInfo().unhealthyEventSources();
+        if (unhealthy.isEmpty()) {
+          builder.withDetail(name, "OK");
+        } else {
+          healthy[0] = false;
+          builder.withDetail(name, "unhealthy: " + String.join(", ", unhealthy.keySet()));
+        }
+      });
+      if (healthy[0]) {
+        builder.up();
+      } else {
+        builder.down();
+      }
+    } else {
+      builder.unknown();
+    }
+  }
+}

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorHealthIndicatorAutoConfiguration.java
@@ -1,0 +1,20 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import io.javaoperatorsdk.operator.Operator;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnBean(Operator.class)
+@ComponentScan("io.javaoperatorsdk.operator.springboot.starter")
+public class OperatorHealthIndicatorAutoConfiguration {
+
+  @Bean
+  public OperatorHealthIndicator createOperatorHealthIndicator(Operator operator) {
+    return new OperatorHealthIndicator(operator);
+  }
+
+}


### PR DESCRIPTION
I stumbled upon [OperatorHealthCheck](https://github.com/quarkiverse/quarkus-operator-sdk/blob/main/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorHealthCheck.java) from the the Quarkus framework and decided to create a health check based on Spring Actuator as well.

The [health indicator](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.endpoints.health) has a autoconfiguration to be only configured when actuator is present.