### PR TITLE
chore: update to josdk v5.0.0-beta1 and fabric8-client v7.0.0 and related fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <jetbrains-annotations.version>26.0.1</jetbrains-annotations.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,14 +59,15 @@
     <maven.compiler.release>17</maven.compiler.release>
     <spotless.version>2.43.0</spotless.version>
     <spring-boot.version>3.3.6</spring-boot.version>
-    <josdk.version>4.9.7</josdk.version>
+    <josdk.version>5.0.0-beta1</josdk.version>
     <surefire.version>3.5.2</surefire.version>
-    <fabric8-client.version>6.13.4</fabric8-client.version>
+    <fabric8-client.version>7.0.0</fabric8-client.version>
     <jenvtest.version>0.9.7</jenvtest.version>
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <jetbrains-annotations.version>26.0.1</jetbrains-annotations.version>
   </properties>
 
   <dependencyManagement>

--- a/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/ConfigMapDependentResource.java
+++ b/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/ConfigMapDependentResource.java
@@ -11,8 +11,7 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernete
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @KubernetesDependent(
-    informer = @Informer(labelSelector = "app.kubernetes.io/managed-by=custom-service-operator")
-)
+    informer = @Informer(labelSelector = "app.kubernetes.io/managed-by=custom-service-operator"))
 public class ConfigMapDependentResource
     extends CRUDKubernetesDependentResource<ConfigMap, CustomService> {
   public ConfigMapDependentResource() {

--- a/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/ConfigMapDependentResource.java
+++ b/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/ConfigMapDependentResource.java
@@ -5,14 +5,17 @@ import java.util.Map;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.operator.api.config.informer.Informer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
-@KubernetesDependent(labelSelector = "app.kubernetes.io/managed-by=custom-service-operator")
-public class ConfigMapDpendentResource
+@KubernetesDependent(
+    informer = @Informer(labelSelector = "app.kubernetes.io/managed-by=custom-service-operator")
+)
+public class ConfigMapDependentResource
     extends CRUDKubernetesDependentResource<ConfigMap, CustomService> {
-  public ConfigMapDpendentResource() {
+  public ConfigMapDependentResource() {
     super(ConfigMap.class);
   }
 

--- a/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/CustomServiceReconciler.java
+++ b/samples/common/src/main/java/io/javaoperatorsdk/operator/springboot/starter/sample/CustomServiceReconciler.java
@@ -15,9 +15,10 @@ import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 
 /** A very simple sample controller that creates a service with a label. */
-@ControllerConfiguration(dependents = {
-    @Dependent(name = "config", type = ConfigMapDpendentResource.class)
+@Workflow(dependents = {
+    @Dependent(name = "config", type = ConfigMapDependentResource.class)
 })
+@ControllerConfiguration
 public class CustomServiceReconciler implements Reconciler<CustomService> {
 
   private static final Logger log = LoggerFactory.getLogger(CustomServiceReconciler.class);
@@ -57,6 +58,6 @@ public class CustomServiceReconciler implements Reconciler<CustomService> {
         .inNamespace(resource.getMetadata().getNamespace())
         .createOrReplace(service);
 
-    return UpdateControl.updateResource(resource);
+    return UpdateControl.patchResource(resource);
   }
 }

--- a/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -20,9 +20,8 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.MockWebServer;
 import io.javaoperatorsdk.operator.springboot.starter.OperatorAutoConfiguration;
-
-import 	io.fabric8.mockwebserver.MockWebServer;
 
 @Configuration
 @ImportAutoConfiguration(OperatorAutoConfiguration.class)

--- a/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
+++ b/starter-test/src/main/java/io/javaoperatorsdk/operator/springboot/starter/test/TestConfiguration.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
 import io.javaoperatorsdk.operator.springboot.starter.OperatorAutoConfiguration;
 
-import okhttp3.mockwebserver.MockWebServer;
+import 	io.fabric8.mockwebserver.MockWebServer;
 
 @Configuration
 @ImportAutoConfiguration(OperatorAutoConfiguration.class)

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -115,5 +115,11 @@
       <artifactId>jenvtest-fabric8-client-support</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${jetbrains-annotations.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -115,11 +115,5 @@
       <artifactId>jenvtest-fabric8-client-support</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>${jetbrains-annotations.version}</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/CRDApplier.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/CRDApplier.java
@@ -7,7 +7,6 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -27,7 +26,7 @@ public interface CRDApplier {
   void apply();
 
   interface CRDTransformer extends UnaryOperator<HasMetadata> {
-    default CRDTransformer thenTransform(@NotNull CRDApplier.CRDTransformer after) {
+    default CRDTransformer thenTransform(CRDApplier.CRDTransformer after) {
       return t -> after.apply(apply(t));
     }
 

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -1,5 +1,23 @@
 package io.javaoperatorsdk.operator.springboot.starter;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -18,23 +36,6 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import io.javaoperatorsdk.operator.springboot.starter.CRDApplier.CRDTransformer;
 import io.javaoperatorsdk.operator.springboot.starter.CRDApplier.DefaultCRDApplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 @Configuration
 @EnableConfigurationProperties(OperatorConfigurationProperties.class)

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
@@ -95,11 +95,13 @@ public class AutoConfigurationTest {
         .satisfies(controller -> {
           assertThat((ControllerConfiguration<?>) controller.getConfiguration())
               .satisfies(config -> {
-                assertThat(config.getInformerConfig().getNamespaces()).containsExactlyInAnyOrder("ns1", "ns2");
+                assertThat(config.getInformerConfig().getNamespaces())
+                    .containsExactlyInAnyOrder("ns1", "ns2");
                 assertThat(config.isGenerationAware()).isTrue();
                 assertThat(config.getName()).isEqualTo("not-a-test-reconciler");
                 assertThat(config.getFinalizerName()).isEqualTo("barton.fink/1991");
-                assertThat(config.getInformerConfig().getLabelSelector()).isEqualTo("version in (v1)");
+                assertThat(config.getInformerConfig().getLabelSelector())
+                    .isEqualTo("version in (v1)");
                 assertThat(config.maxReconciliationInterval()).hasValue(Duration.ofMinutes(3));
               });
           assertThat(controller.getConfiguration().getRetry())

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
@@ -95,11 +95,11 @@ public class AutoConfigurationTest {
         .satisfies(controller -> {
           assertThat((ControllerConfiguration<?>) controller.getConfiguration())
               .satisfies(config -> {
-                assertThat(config.getNamespaces()).containsExactlyInAnyOrder("ns1", "ns2");
+                assertThat(config.getInformerConfig().getNamespaces()).containsExactlyInAnyOrder("ns1", "ns2");
                 assertThat(config.isGenerationAware()).isTrue();
                 assertThat(config.getName()).isEqualTo("not-a-test-reconciler");
                 assertThat(config.getFinalizerName()).isEqualTo("barton.fink/1991");
-                assertThat(config.getLabelSelector()).isEqualTo("version in (v1)");
+                assertThat(config.getInformerConfig().getLabelSelector()).isEqualTo("version in (v1)");
                 assertThat(config.maxReconciliationInterval()).hasValue(Duration.ofMinutes(3));
               });
           assertThat(controller.getConfiguration().getRetry())

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/model/TestResourceList.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/model/TestResourceList.java
@@ -1,6 +1,6 @@
 package io.javaoperatorsdk.operator.springboot.starter.model;
 
-import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 
-public class TestResourceList extends CustomResourceList<TestResource> {
+public class TestResourceList extends DefaultKubernetesResourceList<TestResource> {
 }


### PR DESCRIPTION
Update josdk-spring-boot-starter for compatibility with josdk v5.0.0-beta1 and fabric8 kubernetes-client v7.0.0