### PR TITLE
Move non-mandatory dependencies to test scope

### DIFF
--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -109,6 +109,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.javaoperatorsdk</groupId>
@@ -123,6 +124,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Avoid that non-mandatory dependencies become transitively included by users of josdk-spring-boot-starter