### PR TITLE
feat: create managed dependent resources through Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Reconciler properties [here](./starter/src/main/java/io/javaoperatorsdk/operator
 You can provide own implementation instead of the by default provided beans,
 life for the [Fabric8 client](https://github.com/operator-framework/josdk-spring-boot-starter/blob/main/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java#L50)
 but also the [Operator instance](https://github.com/operator-framework/josdk-spring-boot-starter/blob/main/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java#L94).
+
+By default, managed dependent resources are created through Spring's `AutowireCapableBeanFactory`, so they can
+receive Spring-managed dependencies (e.g. via constructor injection) instead of requiring a no-arg constructor.
+You can provide your own [DependentResourceFactory](https://github.com/operator-framework/josdk-spring-boot-starter/blob/main/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java#L173)
+bean to override this default behavior.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,11 @@ but also the [Operator instance](https://github.com/operator-framework/josdk-spr
 
 By default, managed dependent resources are created through Spring's `AutowireCapableBeanFactory`, so they can
 receive Spring-managed dependencies (e.g. via constructor injection) instead of requiring a no-arg constructor.
+Because of this, dependent resources also go through the same lifecycle as any other Spring bean: fields annotated
+with `@Autowired`/`@Value` are populated, `@PostConstruct` methods run, and matching AOP advice wraps the instance in
+a proxy - this differs from a plain no-arg-constructed instance, so double-check any existing dependent resource that
+relies on annotation-driven injection being a no-op, or on being constructed without side effects.
+
 You can provide your own [DependentResourceFactory](https://github.com/operator-framework/josdk-spring-boot-starter/blob/main/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java#L173)
-bean to override this default behavior.
+bean to override this default behavior, or set `javaoperatorsdk.dependent-resources.spring-managed=false` to fall
+back to Java Operator SDK's own no-arg-constructor default.

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -187,8 +187,11 @@ public class OperatorAutoConfiguration {
   @ConditionalOnBean(DependentResourceFactory.class)
   public Consumer<ConfigurationServiceOverrider> dependentResourceFactoryConfigServiceOverrider(
       ObjectProvider<DependentResourceFactory<?, ?>> dependentResourceFactory) {
+    // ifAvailable() still throws NoUniqueBeanDefinitionException when multiple non-primary
+    // factories are present (same as a direct injection would); ifUnique() degrades gracefully
+    // instead, leaving JOSDK's own default factory in place if the user's beans are ambiguous.
     return overrider -> dependentResourceFactory
-        .ifAvailable(overrider::withDependentResourceFactory);
+        .ifUnique(overrider::withDependentResourceFactory);
   }
 
   private void overrideFromProps(ControllerConfigurationOverrider<?> overrider,

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -9,9 +9,11 @@ import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -170,16 +172,23 @@ public class OperatorAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(DependentResourceFactory.class)
+  @ConditionalOnProperty(
+      prefix = "javaoperatorsdk.dependent-resources",
+      name = "spring-managed",
+      havingValue = "true",
+      matchIfMissing = true)
   public DependentResourceFactory<?, ?> dependentResourceFactory(
       AutowireCapableBeanFactory beanFactory) {
     return new SpringDependentResourceFactory(beanFactory);
   }
 
   @Bean
-  @Order(0)
+  @Order(1)
+  @ConditionalOnBean(DependentResourceFactory.class)
   public Consumer<ConfigurationServiceOverrider> dependentResourceFactoryConfigServiceOverrider(
-      DependentResourceFactory<?, ?> dependentResourceFactory) {
-    return overrider -> overrider.withDependentResourceFactory(dependentResourceFactory);
+      ObjectProvider<DependentResourceFactory<?, ?>> dependentResourceFactory) {
+    return overrider -> dependentResourceFactory
+        .ifAvailable(overrider::withDependentResourceFactory);
   }
 
   private void overrideFromProps(ControllerConfigurationOverrider<?> overrider,

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -34,6 +35,7 @@ import io.javaoperatorsdk.operator.api.config.DefaultResourceClassResolver;
 import io.javaoperatorsdk.operator.api.config.ResourceClassResolver;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import io.javaoperatorsdk.operator.springboot.starter.CRDApplier.CRDTransformer;
 import io.javaoperatorsdk.operator.springboot.starter.CRDApplier.DefaultCRDApplier;
@@ -164,6 +166,20 @@ public class OperatorAutoConfiguration {
           .checkingCRDAndValidateLocalModel(configuration.getCheckCrdAndValidateLocalModel())
           .withKubernetesClient(kubernetesClient);
     };
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(DependentResourceFactory.class)
+  public DependentResourceFactory<?, ?> dependentResourceFactory(
+      AutowireCapableBeanFactory beanFactory) {
+    return new SpringDependentResourceFactory(beanFactory);
+  }
+
+  @Bean
+  @Order(0)
+  public Consumer<ConfigurationServiceOverrider> dependentResourceFactoryConfigServiceOverrider(
+      DependentResourceFactory<?, ?> dependentResourceFactory) {
+    return overrider -> overrider.withDependentResourceFactory(dependentResourceFactory);
   }
 
   private void overrideFromProps(ControllerConfigurationOverrider<?> overrider,

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorConfigurationProperties.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorConfigurationProperties.java
@@ -27,6 +27,7 @@ public class OperatorConfigurationProperties {
   private Boolean ssaBasedCreateUpdateMatchForDependentResources;
   private Boolean useSSAToPatchPrimaryResource;
   private Boolean cloneSecondaryResourcesWhenGettingFromCache;
+  private DependentResourcesProperties dependentResources = new DependentResourcesProperties();
 
   public KubernetesClientProperties getClient() {
     return client;
@@ -152,6 +153,14 @@ public class OperatorConfigurationProperties {
     this.crd = crd;
   }
 
+  public DependentResourcesProperties getDependentResources() {
+    return dependentResources;
+  }
+
+  public void setDependentResources(DependentResourcesProperties dependentResources) {
+    this.dependentResources = dependentResources;
+  }
+
   public static class CrdProperties {
 
     private boolean applyOnStartup;
@@ -186,6 +195,26 @@ public class OperatorConfigurationProperties {
 
     public void setSuffix(String suffix) {
       this.suffix = suffix;
+    }
+  }
+
+  public static class DependentResourcesProperties {
+
+    /**
+     * Whether managed dependent resources should be created through Spring's
+     * {@code AutowireCapableBeanFactory} (default), so that they can receive Spring-managed
+     * dependencies. Set to {@code false} to fall back to Java Operator SDK's default behavior,
+     * which only requires a no-arg constructor and does not run Spring's dependency injection or
+     * bean lifecycle callbacks (e.g. {@code @PostConstruct}) on dependent resource instances.
+     */
+    private boolean springManaged = true;
+
+    public boolean isSpringManaged() {
+      return springManaged;
+    }
+
+    public void setSpringManaged(boolean springManaged) {
+      this.springManaged = springManaged;
     }
   }
 }

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/SpringDependentResourceFactory.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/SpringDependentResourceFactory.java
@@ -1,0 +1,44 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
+
+/**
+ * {@link DependentResourceFactory} that creates managed dependent resource instances through
+ * Spring's {@link AutowireCapableBeanFactory}, instead of relying on a no-arg constructor. This
+ * allows managed dependent resources to receive Spring-managed dependencies, including via
+ * constructor injection, while still going through standard bean post-processing.
+ * <p>
+ * The created instances are not registered as named beans in the application context: each managed
+ * dependent resource keeps the lifecycle expected by Java Operator SDK instead of becoming an
+ * application-wide singleton.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class SpringDependentResourceFactory implements DependentResourceFactory {
+
+  private final AutowireCapableBeanFactory beanFactory;
+
+  public SpringDependentResourceFactory(AutowireCapableBeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+  }
+
+  @Override
+  public DependentResource createFrom(DependentResourceSpec spec,
+      ControllerConfiguration controllerConfiguration) {
+    final DependentResource instance =
+        (DependentResource) beanFactory.createBean(spec.getDependentResourceClass());
+    configure(instance, spec, controllerConfiguration);
+    return instance;
+  }
+
+  @Override
+  public Class<?> associatedResourceType(DependentResourceSpec spec) {
+    final DependentResource instance =
+        (DependentResource) beanFactory.createBean(spec.getDependentResourceClass());
+    return instance.resourceType();
+  }
+}

--- a/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/SpringDependentResourceFactory.java
+++ b/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/SpringDependentResourceFactory.java
@@ -17,8 +17,8 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFac
  * dependent resource keeps the lifecycle expected by Java Operator SDK instead of becoming an
  * application-wide singleton.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
-public class SpringDependentResourceFactory implements DependentResourceFactory {
+public class SpringDependentResourceFactory
+    implements DependentResourceFactory<ControllerConfiguration<?>, DependentResourceSpec> {
 
   private final AutowireCapableBeanFactory beanFactory;
 
@@ -28,7 +28,7 @@ public class SpringDependentResourceFactory implements DependentResourceFactory 
 
   @Override
   public DependentResource createFrom(DependentResourceSpec spec,
-      ControllerConfiguration controllerConfiguration) {
+      ControllerConfiguration<?> controllerConfiguration) {
     final DependentResource instance =
         (DependentResource) beanFactory.createBean(spec.getDependentResourceClass());
     configure(instance, spec, controllerConfiguration);
@@ -37,8 +37,18 @@ public class SpringDependentResourceFactory implements DependentResourceFactory 
 
   @Override
   public Class<?> associatedResourceType(DependentResourceSpec spec) {
+    // Falling back to the reflection-based default (DependentResourceFactory.super) isn't an
+    // option here: it requires a no-arg constructor, which constructor-injected dependent
+    // resources - the whole point of this factory - don't have. So a throwaway instance still
+    // has to be created through Spring, but unlike AutowireCapableBeanFactory.createBean(Class),
+    // it must also be destroyed afterward, since the contract puts destruction on the caller and
+    // JOSDK never gets a reference to this instance to do so itself.
     final DependentResource instance =
         (DependentResource) beanFactory.createBean(spec.getDependentResourceClass());
-    return instance.resourceType();
+    try {
+      return instance.resourceType();
+    } finally {
+      beanFactory.destroyBean(instance);
+    }
   }
 }

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/AutoConfigurationTest.java
@@ -123,6 +123,12 @@ public class AutoConfigurationTest {
   }
 
   @Test
+  public void createsSpringDependentResourceFactoryByDefault() {
+    assertThat(operator.getConfigurationService().dependentResourceFactory())
+        .isInstanceOf(SpringDependentResourceFactory.class);
+  }
+
+  @Test
   public void reconcilersAreDiscovered() {
     assertEquals(1, reconcilers.size());
     assertTrue(reconcilers.get(0) instanceof TestReconciler);

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/DependentResourceFactoryConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/DependentResourceFactoryConfigurationTest.java
@@ -1,0 +1,34 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DependentResourceFactoryConfigurationTest {
+
+  private static final ApplicationContextRunner runner = new ApplicationContextRunner()
+      .withUserConfiguration(OperatorAutoConfiguration.class)
+      .withBean(Operator.class, () -> mock(Operator.class));
+
+  @Test
+  void createsSpringDependentResourceFactoryByDefault() {
+    runner.run(ctx -> assertThat(ctx)
+        .getBean(DependentResourceFactory.class)
+        .isInstanceOf(SpringDependentResourceFactory.class));
+  }
+
+  @Test
+  void userProvidedDependentResourceFactoryTakesPrecedence() {
+    DependentResourceFactory<?, ?> custom = mock(DependentResourceFactory.class);
+
+    runner.withBean("customDependentResourceFactory", DependentResourceFactory.class, () -> custom)
+        .run(ctx -> assertThat(ctx)
+            .getBean(DependentResourceFactory.class)
+            .isSameAs(custom));
+  }
+}

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/DependentResourceFactoryConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/DependentResourceFactoryConfigurationTest.java
@@ -31,4 +31,22 @@ class DependentResourceFactoryConfigurationTest {
             .getBean(DependentResourceFactory.class)
             .isSameAs(custom));
   }
+
+  @Test
+  void doesNotCreateSpringDependentResourceFactoryWhenDisabledByProperty() {
+    // with no factory bean to fall back on, JOSDK keeps using its own reflection-based default.
+    runner.withPropertyValues("javaoperatorsdk.dependent-resources.spring-managed=false")
+        .run(ctx -> assertThat(ctx).doesNotHaveBean(DependentResourceFactory.class));
+  }
+
+  @Test
+  void userProvidedDependentResourceFactoryStillAppliesWhenDisabledByProperty() {
+    DependentResourceFactory<?, ?> custom = mock(DependentResourceFactory.class);
+
+    runner.withPropertyValues("javaoperatorsdk.dependent-resources.spring-managed=false")
+        .withBean("customDependentResourceFactory", DependentResourceFactory.class, () -> custom)
+        .run(ctx -> assertThat(ctx)
+            .getBean(DependentResourceFactory.class)
+            .isSameAs(custom));
+  }
 }

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/DependentResourceFactoryConfigurationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/DependentResourceFactoryConfigurationTest.java
@@ -1,13 +1,20 @@
 package io.javaoperatorsdk.operator.springboot.starter;
 
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class DependentResourceFactoryConfigurationTest {
 
@@ -48,5 +55,27 @@ class DependentResourceFactoryConfigurationTest {
         .run(ctx -> assertThat(ctx)
             .getBean(DependentResourceFactory.class)
             .isSameAs(custom));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void ambiguousUserProvidedFactoriesAreLeftForJosdksOwnDefaultInsteadOfFailing() {
+    // two non-primary DependentResourceFactory beans are ambiguous; applying the overrider must
+    // not try to resolve one of them (that would throw NoUniqueBeanDefinitionException) and
+    // should instead leave JOSDK's own default factory in place.
+    DependentResourceFactory<?, ?> first = mock(DependentResourceFactory.class);
+    DependentResourceFactory<?, ?> second = mock(DependentResourceFactory.class);
+
+    runner.withBean("firstDependentResourceFactory", DependentResourceFactory.class, () -> first)
+        .withBean("secondDependentResourceFactory", DependentResourceFactory.class, () -> second)
+        .run(ctx -> {
+          Consumer<ConfigurationServiceOverrider> overriderConsumer =
+              (Consumer<ConfigurationServiceOverrider>) ctx
+                  .getBean("dependentResourceFactoryConfigServiceOverrider");
+          ConfigurationServiceOverrider overrider = mock(ConfigurationServiceOverrider.class);
+
+          assertThatCode(() -> overriderConsumer.accept(overrider)).doesNotThrowAnyException();
+          verify(overrider, never()).withDependentResourceFactory(any());
+        });
   }
 }

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/GreetingService.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/GreetingService.java
@@ -1,0 +1,6 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+public interface GreetingService {
+
+  String greeting();
+}

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/NoArgConstructorDependentResource.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/NoArgConstructorDependentResource.java
@@ -1,0 +1,25 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.springboot.starter.model.TestResource;
+
+public class NoArgConstructorDependentResource
+    extends CRUDKubernetesDependentResource<ConfigMap, TestResource> {
+
+  public NoArgConstructorDependentResource() {
+    super(ConfigMap.class);
+  }
+
+  @Override
+  protected ConfigMap desired(TestResource primary, Context<TestResource> context) {
+    return new ConfigMapBuilder()
+        .withNewMetadata()
+        .withName(primary.getMetadata().getName() + "-no-arg")
+        .withNamespace(primary.getMetadata().getNamespace())
+        .endMetadata()
+        .build();
+  }
+}

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringDependentResourceFactoryTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringDependentResourceFactoryTest.java
@@ -1,0 +1,74 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class SpringDependentResourceFactoryTest {
+
+  private final AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+  private final SpringDependentResourceFactory factory =
+      new SpringDependentResourceFactory(beanFactory);
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void associatedResourceTypeDestroysTheThrowawayInstanceItCreated() {
+    DependentResourceSpec spec = mock(DependentResourceSpec.class);
+    when(spec.getDependentResourceClass())
+        .thenReturn((Class) NoArgConstructorDependentResource.class);
+    NoArgConstructorDependentResource instance = new NoArgConstructorDependentResource();
+    when(beanFactory.createBean(NoArgConstructorDependentResource.class)).thenReturn(instance);
+
+    Class<?> resourceType = factory.associatedResourceType(spec);
+
+    assertThat(resourceType).isEqualTo(instance.resourceType());
+    InOrder inOrder = inOrder(beanFactory);
+    inOrder.verify(beanFactory).createBean(NoArgConstructorDependentResource.class);
+    inOrder.verify(beanFactory).destroyBean(instance);
+    verifyNoMoreInteractions(beanFactory);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void associatedResourceTypeDestroysTheThrowawayInstanceEvenOnFailure() {
+    DependentResourceSpec spec = mock(DependentResourceSpec.class);
+    when(spec.getDependentResourceClass())
+        .thenReturn((Class) NoArgConstructorDependentResource.class);
+    NoArgConstructorDependentResource instance = mock(NoArgConstructorDependentResource.class);
+    when(beanFactory.createBean(NoArgConstructorDependentResource.class)).thenReturn(instance);
+    when(instance.resourceType()).thenThrow(new IllegalStateException("boom"));
+
+    org.junit.jupiter.api.function.Executable call = () -> factory.associatedResourceType(spec);
+
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, call);
+    verify(beanFactory).destroyBean(instance);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void createFromDoesNotDestroyTheReturnedInstance() {
+    DependentResourceSpec spec = mock(DependentResourceSpec.class);
+    when(spec.getDependentResourceClass())
+        .thenReturn((Class) NoArgConstructorDependentResource.class);
+    NoArgConstructorDependentResource instance = new NoArgConstructorDependentResource();
+    when(beanFactory.createBean(NoArgConstructorDependentResource.class)).thenReturn(instance);
+    ControllerConfiguration<?> controllerConfiguration = mock(ControllerConfiguration.class);
+
+    var created = factory.createFrom(spec, controllerConfiguration);
+
+    assertThat(created).isSameAs(instance);
+    verify(beanFactory).createBean(NoArgConstructorDependentResource.class);
+    verify(beanFactory, org.mockito.Mockito.never()).destroyBean(any());
+  }
+}

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentReconciler.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentReconciler.java
@@ -12,7 +12,8 @@ import io.javaoperatorsdk.operator.springboot.starter.model.TestResource;
 public class SpringManagedDependentReconciler implements Reconciler<TestResource> {
 
   @Override
-  public UpdateControl<TestResource> reconcile(TestResource testResource, Context context) {
+  public UpdateControl<TestResource> reconcile(TestResource testResource,
+      Context<TestResource> context) {
     return UpdateControl.noUpdate();
   }
 }

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentReconciler.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentReconciler.java
@@ -1,0 +1,18 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.springboot.starter.model.TestResource;
+
+@ControllerConfiguration
+@Workflow(dependents = {
+    @Dependent(type = SpringManagedDependentResource.class),
+    @Dependent(type = NoArgConstructorDependentResource.class)
+})
+public class SpringManagedDependentReconciler implements Reconciler<TestResource> {
+
+  @Override
+  public UpdateControl<TestResource> reconcile(TestResource testResource, Context context) {
+    return UpdateControl.noUpdate();
+  }
+}

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResource.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResource.java
@@ -1,0 +1,39 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.springboot.starter.model.TestResource;
+
+public class SpringManagedDependentResource
+    extends CRUDKubernetesDependentResource<ConfigMap, TestResource> {
+
+  static final AtomicReference<SpringManagedDependentResource> LAST_CREATED_INSTANCE =
+      new AtomicReference<>();
+
+  private final GreetingService greetingService;
+
+  public SpringManagedDependentResource(GreetingService greetingService) {
+    super(ConfigMap.class);
+    this.greetingService = greetingService;
+    LAST_CREATED_INSTANCE.set(this);
+  }
+
+  GreetingService getGreetingService() {
+    return greetingService;
+  }
+
+  @Override
+  protected ConfigMap desired(TestResource primary, Context<TestResource> context) {
+    return new ConfigMapBuilder()
+        .withNewMetadata()
+        .withName(primary.getMetadata().getName())
+        .withNamespace(primary.getMetadata().getNamespace())
+        .endMetadata()
+        .addToData("greeting", greetingService.greeting())
+        .build();
+  }
+}

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResource.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResource.java
@@ -11,6 +11,15 @@ import io.javaoperatorsdk.operator.springboot.starter.model.TestResource;
 public class SpringManagedDependentResource
     extends CRUDKubernetesDependentResource<ConfigMap, TestResource> {
 
+  /**
+   * {@link SpringDependentResourceFactory#associatedResourceType} also constructs (and destroys) a
+   * throwaway instance of this class during controller registration, before the workflow - and with
+   * it, the instance {@link SpringDependentResourceFactory#createFrom} produces - is built. So this
+   * field always ends up holding the real, workflow-registered instance, not the throwaway one;
+   * {@link SpringManagedDependentResourceIntegrationTest#managedDependentResourceIsStillConfiguredByJosdk()}
+   * cross-checks that by asserting {@link #configuration()} is present, which only the workflow
+   * instance goes through.
+   */
   static final AtomicReference<SpringManagedDependentResource> LAST_CREATED_INSTANCE =
       new AtomicReference<>();
 

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResourceIntegrationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResourceIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.springboot.starter;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,14 @@ public class SpringManagedDependentResourceIntegrationTest {
 
   @Autowired
   private GreetingService greetingService;
+
+  @AfterAll
+  static void resetLastCreatedInstance() {
+    // The static holder is only ever written to during context startup (a single dependent
+    // resource instance for the whole test class), but clear it once the class is done so it
+    // can't leak into other test classes sharing the JVM.
+    SpringManagedDependentResource.LAST_CREATED_INSTANCE.set(null);
+  }
 
   @Test
   void managedDependentResourceIsCreatedThroughSpringAndReceivesInjectedBean() {

--- a/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResourceIntegrationTest.java
+++ b/starter/src/test/java/io/javaoperatorsdk/operator/springboot/starter/SpringManagedDependentResourceIntegrationTest.java
@@ -1,0 +1,96 @@
+package io.javaoperatorsdk.operator.springboot.starter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+
+@SpringBootTest(properties = {
+    "javaoperatorsdk.client.masterUrl=http://master.url",
+    "javaoperatorsdk.client.username=user",
+    "javaoperatorsdk.client.password=password",
+    "javaoperatorsdk.client.oauthToken=token"
+})
+public class SpringManagedDependentResourceIntegrationTest {
+
+  @MockitoSpyBean
+  private Operator operator;
+
+  @Autowired
+  private GreetingService greetingService;
+
+  @Test
+  void managedDependentResourceIsCreatedThroughSpringAndReceivesInjectedBean() {
+    var dependentResource = SpringManagedDependentResource.LAST_CREATED_INSTANCE.get();
+
+    assertThat(dependentResource).isNotNull();
+    assertThat(dependentResource.getGreetingService()).isSameAs(greetingService);
+  }
+
+  @Test
+  void managedDependentResourceIsStillConfiguredByJosdk() {
+    var dependentResource = SpringManagedDependentResource.LAST_CREATED_INSTANCE.get();
+
+    assertThat(dependentResource.configuration()).isPresent();
+  }
+
+  @Test
+  void managedDependentResourcesAreRegisteredInTheReconcilerWorkflow() {
+    var controller = operator
+        .getRegisteredController(
+            ReconcilerUtilsInternal.getNameFor(SpringManagedDependentReconciler.class))
+        .orElseThrow();
+
+    ControllerConfiguration<?> configuration = controller.getConfiguration();
+    var dependentResourceClasses = configuration.getWorkflowSpec()
+        .orElseThrow()
+        .getDependentResourceSpecs()
+        .stream()
+        .map(spec -> spec.getDependentResourceClass())
+        .toList();
+
+    assertThat(dependentResourceClasses)
+        .containsExactlyInAnyOrder(SpringManagedDependentResource.class,
+            NoArgConstructorDependentResource.class);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+
+    @Bean
+    public GreetingService greetingService() {
+      return () -> "hello from spring";
+    }
+
+    @Bean
+    public Reconciler<?> springManagedDependentReconciler() {
+      return new SpringManagedDependentReconciler();
+    }
+
+    @Bean
+    public BeanPostProcessor operatorStartSuppressor() {
+      return new BeanPostProcessor() {
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName)
+            throws BeansException {
+          if (bean instanceof Operator operator) {
+            doNothing().when(operator).start();
+          }
+          return bean;
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- create managed dependent resources through Spring's `AutowireCapableBeanFactory` instead of reflection, so they can receive Spring-managed dependencies (including via constructor injection)
- preserve Java Operator SDK's dependent-resource configuration step (`configureWith`) for dependent resources that implement `ConfiguredDependentResource`
- allow applications to override the default by providing their own `DependentResourceFactory` bean (`@ConditionalOnMissingBean`)
- add focused Spring Boot integration coverage for constructor injection, workflow registration, JOSDK configuration, factory override, and the existing no-arg-constructor path

## Testing

- `./mvnw -pl starter -am test -Dtest=SpringManagedDependentResourceIntegrationTest,DependentResourceFactoryConfigurationTest,AutoConfigurationTest`
- `./mvnw test` (all modules)
- `./mvnw verify` (all modules)
- `./mvnw spotless:apply` / `./mvnw spotless:check`

Related to operator-framework/java-operator-sdk#2166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spring-managed dependent resource support with dependency injection and bean lifecycle processing.
  * Added configuration to enable or disable Spring-managed dependent resources, enabled by default.
  * Custom dependent resource factories continue to be supported and take precedence when provided.

* **Documentation**
  * Documented Spring-managed resource behavior, lifecycle callbacks, AOP support, and configuration options.

* **Tests**
  * Added coverage for default, custom, disabled, injection, workflow registration, and lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->